### PR TITLE
Feature/food create

### DIFF
--- a/src/main/java/com/example/fooddelivery/food/controller/FoodController.java
+++ b/src/main/java/com/example/fooddelivery/food/controller/FoodController.java
@@ -1,12 +1,13 @@
 package com.example.fooddelivery.food.controller;
 
+import com.example.fooddelivery.food.dto.FoodRequestDto;
 import com.example.fooddelivery.food.service.FoodService;
 import com.example.fooddelivery.food.dto.FoodResponseDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
 
 @RestController
 public class FoodController {
@@ -20,5 +21,11 @@ public class FoodController {
     @GetMapping("/api/v1/foods/{id}")
     public ResponseEntity<FoodResponseDto> getFood(@PathVariable Long id) {
         return ResponseEntity.ok().body(foodService.getFood(id));
+    }
+
+    @PostMapping("/api/v1/foods")
+    public ResponseEntity<?> createFood(@RequestBody FoodRequestDto requestDto) {
+        Long id = foodService.createFood(requestDto);
+        return ResponseEntity.created(URI.create("/api/v1/foods/" + id)).build();
     }
 }

--- a/src/main/java/com/example/fooddelivery/food/dto/FoodRequestDto.java
+++ b/src/main/java/com/example/fooddelivery/food/dto/FoodRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.fooddelivery.food.dto;
+
+import com.example.fooddelivery.food.domain.Food;
+import lombok.Getter;
+
+@Getter
+public class FoodRequestDto {
+    private String name;
+    private int price;
+
+    public Food toEntity() {
+        return Food.createFood(name, price);
+    }
+}

--- a/src/main/java/com/example/fooddelivery/food/service/FoodService.java
+++ b/src/main/java/com/example/fooddelivery/food/service/FoodService.java
@@ -1,5 +1,6 @@
 package com.example.fooddelivery.food.service;
 
+import com.example.fooddelivery.food.dto.FoodRequestDto;
 import com.example.fooddelivery.food.repository.FoodRepository;
 import com.example.fooddelivery.food.domain.Food;
 import com.example.fooddelivery.food.dto.FoodResponseDto;
@@ -22,5 +23,11 @@ public class FoodService {
                 () -> new IllegalArgumentException("음식이 존재하지 않습니다.")
         );
         return new FoodResponseDto(food);
+    }
+
+    @Transactional
+    public Long createFood(FoodRequestDto requestDto) {
+        Food food = requestDto.toEntity();
+        return foodRepository.save(food).getId();
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,3 +1,3 @@
-insert into food (id, name, price, created_at, modified_at) values (1, 'pizza', 15000, null, null);
-insert into food (id, name, price, created_at, modified_at) values (2, 'chicken', 20000, null, null);
-insert into food (id, name, price, created_at, modified_at) values (3, 'hamberger', 7000, null, null);
+insert into food (name, price, created_at, modified_at) values ('pizza', 15000, null, null);
+insert into food (name, price, created_at, modified_at) values ('chicken', 20000, null, null);
+insert into food (name, price, created_at, modified_at) values ('hamberger', 7000, null, null);


### PR DESCRIPTION
### PR 타입
-기능 추가

### 반영 브랜치
featrue/food-create -> dev

### 변경 사항
1. food entity 생성 후 DB에 저장하는 기능 구현
2. 초기 데이터로 인해 DB 저장 기능 문제 발생으로 인해 sql 수정

### 문제 사항
#### 상황
food entity 생성 후 DB에 저장하는 테스트에서 오류 발생

#### 문제 파악
확인 결과 pk 중복으로 인한 오류 발생

#### 해결 방법
서비스 DB는 mariaDB를 사용하기 때문에 IDENTITY 전략을 사용했다.
그러나 테스트는 H2로 진행해 IDENTITY 기능을 사용 불가
따라서 초기 데이터 INSERT 시 pk 값을 H2에서 지정하게 하도록 하여 문제 해결
