### PR TITLE
Feature/create menu

### DIFF
--- a/src/main/java/com/example/fooddelivery/menu/controller/MenuController.java
+++ b/src/main/java/com/example/fooddelivery/menu/controller/MenuController.java
@@ -1,0 +1,31 @@
+package com.example.fooddelivery.menu.controller;
+
+import com.example.fooddelivery.menu.dto.CreateMenuReqDto;
+import com.example.fooddelivery.menu.dto.MenuResDto;
+import com.example.fooddelivery.menu.service.MenuService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/v1/menus")
+public class MenuController {
+
+    private final MenuService menuService;
+
+    @Autowired
+    public MenuController(MenuService menuService) {
+        this.menuService = menuService;
+    }
+
+    @PostMapping("")
+    public ResponseEntity<MenuResDto> createMenu(@RequestBody CreateMenuReqDto requestDto) {
+        Long id = menuService.createMenu(requestDto).getId();
+        return ResponseEntity.created(URI.create("/api/v1/menus/" + id)).build();
+    }
+}

--- a/src/main/java/com/example/fooddelivery/menu/domain/Menu.java
+++ b/src/main/java/com/example/fooddelivery/menu/domain/Menu.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
-@Table(name = "menu")
+@Table(name = "menus")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -22,13 +22,13 @@ public class Menu extends TimeStamped {
     @Column(name = "price", nullable = false)
     private int price;
 
-    @Column(name = "describe", nullable = false)
+    @Column(name = "describes", nullable = false)
     private String describe;
 
-    @Column(name = "is-display", nullable = false)
+    @Column(name = "is_display", nullable = false)
     private boolean isDisplay;
 
-    @Column(name = "menu-status", nullable = false)
+    @Column(name = "menu_status", nullable = false)
     @Enumerated(EnumType.STRING)
     private MenuStatus menuStatus;
 

--- a/src/main/java/com/example/fooddelivery/menu/domain/Menu.java
+++ b/src/main/java/com/example/fooddelivery/menu/domain/Menu.java
@@ -33,9 +33,14 @@ public class Menu extends TimeStamped {
     private MenuStatus menuStatus;
 
     private Menu(String name, int price, String describe) {
+        if (price < 0) {
+            throw new IllegalArgumentException();
+        }
         this.name = name;
         this.price = price;
         this.describe = describe;
+        this.isDisplay = false;
+        this.menuStatus = MenuStatus.SALE;
     }
 
     public static Menu createMenu(String name, int price, String describe) {

--- a/src/main/java/com/example/fooddelivery/menu/dto/CreateMenuReqDto.java
+++ b/src/main/java/com/example/fooddelivery/menu/dto/CreateMenuReqDto.java
@@ -1,0 +1,18 @@
+package com.example.fooddelivery.menu.dto;
+
+import com.example.fooddelivery.menu.domain.Menu;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CreateMenuReqDto {
+    private String name;
+    private int price;
+    private String describe;
+    private List<FoodQuantityReqDto> foodReqList;
+
+    public Menu toEntity() {
+        return Menu.createMenu(name, price, describe);
+    }
+}

--- a/src/main/java/com/example/fooddelivery/menu/dto/FoodQuantityReqDto.java
+++ b/src/main/java/com/example/fooddelivery/menu/dto/FoodQuantityReqDto.java
@@ -1,0 +1,9 @@
+package com.example.fooddelivery.menu.dto;
+
+import lombok.Getter;
+
+@Getter
+public class FoodQuantityReqDto {
+    private Long id;
+    private int quantity;
+}

--- a/src/main/java/com/example/fooddelivery/menu/dto/MenuResDto.java
+++ b/src/main/java/com/example/fooddelivery/menu/dto/MenuResDto.java
@@ -1,0 +1,24 @@
+package com.example.fooddelivery.menu.dto;
+
+import com.example.fooddelivery.menu.domain.Menu;
+import com.example.fooddelivery.menu.domain.MenuStatus;
+import lombok.Getter;
+
+@Getter
+public class MenuResDto {
+    private Long id;
+    private String name;
+    private int price;
+    private String describe;
+    private boolean isDisplay;
+    private MenuStatus status;
+
+    public MenuResDto(Menu menu) {
+        this.id = menu.getId();
+        this.name = menu.getName();
+        this.price = menu.getPrice();
+        this.describe = menu.getDescribe();
+        this.isDisplay = menu.isDisplay();
+        this.status = menu.getMenuStatus();
+    }
+}

--- a/src/main/java/com/example/fooddelivery/menu/repository/MenuRepository.java
+++ b/src/main/java/com/example/fooddelivery/menu/repository/MenuRepository.java
@@ -1,0 +1,9 @@
+package com.example.fooddelivery.menu.repository;
+
+import com.example.fooddelivery.menu.domain.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+}

--- a/src/main/java/com/example/fooddelivery/menu/service/MenuService.java
+++ b/src/main/java/com/example/fooddelivery/menu/service/MenuService.java
@@ -1,0 +1,48 @@
+package com.example.fooddelivery.menu.service;
+
+import com.example.fooddelivery.common.exception.NotFoundException;
+import com.example.fooddelivery.food.domain.Food;
+import com.example.fooddelivery.food.repository.FoodRepository;
+import com.example.fooddelivery.menu.domain.Menu;
+import com.example.fooddelivery.menu.dto.CreateMenuReqDto;
+import com.example.fooddelivery.menu.dto.FoodQuantityReqDto;
+import com.example.fooddelivery.menu.dto.MenuResDto;
+import com.example.fooddelivery.menu.repository.MenuRepository;
+import com.example.fooddelivery.menufood.domain.MenuFood;
+import com.example.fooddelivery.menufood.repository.MenuFoodRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class MenuService {
+
+    private final MenuRepository menuRepository;
+    private final FoodRepository foodRepository;
+    private final MenuFoodRepository menuFoodRepository;
+
+    @Autowired
+    public MenuService(MenuRepository menuRepository, FoodRepository foodRepository, MenuFoodRepository menuFoodRepository) {
+        this.menuRepository = menuRepository;
+        this.foodRepository = foodRepository;
+        this.menuFoodRepository = menuFoodRepository;
+    }
+
+    public MenuResDto createMenu(CreateMenuReqDto requestDto) {
+
+        Menu saveMenu = menuRepository.save(requestDto.toEntity());
+
+        List<FoodQuantityReqDto> foodIdQuantityList = requestDto.getFoodReqList();
+        for (FoodQuantityReqDto req : foodIdQuantityList) {
+            Food food = foodRepository.findById(req.getId()).orElseThrow(
+                    () -> new NotFoundException("음식을 찾지 못했습니다.")
+            );
+
+            MenuFood menuFood = MenuFood.createMenuFood(req.getQuantity(), saveMenu, food);
+            menuFoodRepository.save(menuFood);
+        }
+
+        return new MenuResDto(saveMenu);
+    }
+}

--- a/src/main/java/com/example/fooddelivery/menufood/domain/MenuFood.java
+++ b/src/main/java/com/example/fooddelivery/menufood/domain/MenuFood.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
-@Table(name = "menu-food")
+@Table(name = "menu_food")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -18,13 +18,15 @@ public class MenuFood extends TimeStamped {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "quantity", nullable = false)
+    @Column(name = "food_quantity", nullable = false)
     private int quantity;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_id")
     private Menu menu;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "food_id")
     private Food food;
 
     private MenuFood(int quantity, Menu menu, Food food) {

--- a/src/main/java/com/example/fooddelivery/menufood/repository/MenuFoodRepository.java
+++ b/src/main/java/com/example/fooddelivery/menufood/repository/MenuFoodRepository.java
@@ -1,0 +1,9 @@
+package com.example.fooddelivery.menufood.repository;
+
+import com.example.fooddelivery.menufood.domain.MenuFood;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MenuFoodRepository extends JpaRepository<MenuFood, Long> {
+}


### PR DESCRIPTION
### PR 타입
-기능 추가

### 반영 브랜치
featrue/create-menu -> dev

### 변경 사항
1. menu  entity 생성 후 저장하는 기능 추가
2. entity 테이블 및 컬럼 이름 수정

### 문제 사항
#### 상황
menu 및 menu-food 테이블 생성 오류 발생

#### 문제 파악
확인 결과 예약어 및 sql 문법에 맞지 않는 방식의 명칭 사용
('-' 사용)

#### 해결 방법
테이블과 컬럼 이름에 '-'가 아닌 _를 사용하여 문제를 해결
이후 예약어 사용을 방지하기 위해  복수형 명사를 사용하도록 변경 